### PR TITLE
Feature/fix crash

### DIFF
--- a/UltraPickerIOS/UltraPickerIOS/UltraPickerIOSView.m
+++ b/UltraPickerIOS/UltraPickerIOS/UltraPickerIOSView.m
@@ -33,7 +33,9 @@ NSString const *UIPickerDefaultFontFamily = @"HelveticaNeue";
     }
     for (NSInteger i = 0; i < selectedIndexes.count; i++) {
         NSInteger index = [selectedIndexes[i] integerValue];
-        [self selectRow:index inComponent:i animated:NO];
+        if (index) {
+            [self selectRow:index inComponent:i animated:NO];
+        }
     }
 }
 

--- a/example/.babelrc
+++ b/example/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["react-native"]
+    "presets": ["module:metro-react-native-babel-preset"]
 }

--- a/example/package.json
+++ b/example/package.json
@@ -8,15 +8,15 @@
 		"test": "jest"
 	},
 	"dependencies": {
-		"react": "^16.0",
-		"react-native": "^0.48.1"
+		"react": "16.5.0",
+		"react-native": "0.57.2"
 	},
 	"devDependencies": {
 		"babel-jest": "20.0.3",
-		"babel-preset-react-native": "3.0.2",
 		"jest": "20.0.4",
 		"react-native-ultra-picker-ios": "file:../",
-		"react-test-renderer": "16.0.0-alpha.12"
+		"react-test-renderer": "^16.0.0",
+		"metro-react-native-babel-preset": "^0.47.1"
 	},
 	"jest": {
 		"preset": "react-native"

--- a/js/UltraPickerIOS.js
+++ b/js/UltraPickerIOS.js
@@ -6,24 +6,30 @@
 //  Copyright © 2017 Sportsbet. All rights reserved.
 //
 var __extends = (this && this.__extends) || (function () {
-    var extendStatics = Object.setPrototypeOf ||
-        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
     return function (d, b) {
         extendStatics(d, b);
         function __() { this.constructor = d; }
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var s, i = 1, n = arguments.length; i < n; i++) {
-        s = arguments[i];
-        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-            t[p] = s[p];
-    }
-    return t;
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
 };
-Object.defineProperty(exports, "__esModule", { value: true });
+exports.__esModule = true;
 var React = require("react");
 var react_native_1 = require("react-native");
 var react_native_2 = require("react-native");
@@ -141,9 +147,10 @@ var UltraPickerIOS = /** @class */ (function (_super) {
         if (this.state.closeBar) {
             parentViewStyle.height = parentViewStyle.height + DEFAULT_CLOSEBAR_HEIGHT;
         }
-        return (React.createElement(react_native_1.View, { style: parentViewStyle },
-            this.state.closeBar,
-            React.createElement(UltraPickerIOSNative, { style: pickerViewStyle, onChange: this.props.onChange, componentsData: this.state.componentsData, selectedIndexes: this.state.selectedIndexes, testID: this.props.testID })));
+        return (<react_native_1.View style={parentViewStyle}>
+                {this.state.closeBar}
+                <UltraPickerIOSNative style={pickerViewStyle} onChange={this.props.onChange} componentsData={this.state.componentsData} selectedIndexes={this.state.selectedIndexes} testID={this.props.testID}/>
+            </react_native_1.View>);
     };
     return UltraPickerIOS;
 }(React.Component));
@@ -156,7 +163,7 @@ var UltraPickerIOSCloseBar = /** @class */ (function (_super) {
     UltraPickerIOSCloseBar.prototype.render = function () {
         var style = __assign({ height: DEFAULT_CLOSEBAR_HEIGHT }, react_native_1.StyleSheet.flatten(this.props.style));
         var closeButtonText = this.props.closeButtonText || "Close";
-        return (React.createElement(UltraPickerIOSCloseBarNative, { style: style || this.props.style, closeButtonText: closeButtonText, onClose: this.props.onClose, buttonTestID: this.props.buttonTestID }));
+        return (<UltraPickerIOSCloseBarNative style={style || this.props.style} closeButtonText={closeButtonText} onClose={this.props.onClose} buttonTestID={this.props.buttonTestID}/>);
     };
     return UltraPickerIOSCloseBar;
 }(React.Component));

--- a/ts/UltraPickerIOS.tsx
+++ b/ts/UltraPickerIOS.tsx
@@ -9,7 +9,9 @@ import * as React from 'react';
 import {
   StyleSheet,
   View,
-  ViewStyle
+  ViewStyle,
+  NativeSyntheticEvent,
+  StyleProp
 } from 'react-native';
 
 import { requireNativeComponent } from 'react-native';
@@ -22,14 +24,14 @@ interface UltraPickerIOSNative {
     componentsData?: any,
     selectedIndexes?: Number[]
     onChange?: (result: any) => void
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
     testID?: string
 }
 
 interface UltraPickerIOSCloseBarNative {
     closeButtonText?: string
     onClose?: (result: any) => void
-    style?: ViewStyle
+    style?: StyleProp<ViewStyle>
     buttonTestID?: string
 }
 
@@ -62,9 +64,16 @@ export class Item extends React.Component<ComponentItemProps> {
     }
 }
 
+export interface UltraPickerChangeEvent {
+    newIndex: number
+    component: number
+    newValue: string
+    newLabel: string
+}
+
 export interface UltraPickerIOSProps {
-    onChange?: (result: any) => void
-    style: ViewStyle
+    onChange?: (result: NativeSyntheticEvent<UltraPickerChangeEvent>) => void
+    style: StyleProp<ViewStyle>
     testID?: string
 }
 
@@ -184,7 +193,7 @@ export class UltraPickerIOS extends React.Component<UltraPickerIOSProps, UltraPi
 export interface UltraPickerIOSCloseBarProps {
     closeButtonText?: string
     onClose?: (result: any) => void
-    style?: ViewStyle,
+    style?: StyleProp<ViewStyle>,
     buttonTestID?: string
 }
 


### PR DESCRIPTION
This PR fixes a bug that gets triggered after selecting a picker when another picker has been already presented and the second one has less sections than the first.

It also updates the RN version for the example and the type definitions for the Picker TSX file.